### PR TITLE
Allows AbstractStreamResource as images for Zoomist

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/addons/zoomist/Zoomist.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/zoomist/Zoomist.java
@@ -25,6 +25,7 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.server.AbstractStreamResource;
 import com.vaadin.flow.shared.Registration;
 import elemental.json.Json;
 import elemental.json.JsonObject;
@@ -79,6 +80,24 @@ public class Zoomist extends Component {
    */
   public Zoomist(String src) {
     setSrc(src);
+  }
+
+  /**
+   * Creates a new instance of Zoomist for the specified source image.
+   *
+   * @param src the source image
+   */
+  public Zoomist(AbstractStreamResource src) {
+    setSrc(src);
+  }
+
+  /**
+   * Sets the source url of image.
+   *
+   * @param src the source image
+   */
+  public void setSrc(AbstractStreamResource src) {
+    getElement().setAttribute("src", src);
   }
 
   /**


### PR DESCRIPTION
Currently Zoomist only allows String parameter for src.
When getting images via API as byte[] the Image is handled as StreamResource:

```
StreamResource streamResource = new StreamResource("image.png", () -> {
            byte[] imageBytes = myApi.getImage(id);
            return new ByteArrayInputStream(imageBytes);
        });
```

The change allows to use Zoomist also with StreamResource